### PR TITLE
Undefined behavior fix.

### DIFF
--- a/simplemad_sys/libmad-src/frame.c
+++ b/simplemad_sys/libmad-src/frame.c
@@ -67,7 +67,7 @@ int (*const decoder_table[3])(struct mad_stream *, struct mad_frame *) = {
  */
 void mad_header_init(struct mad_header *header)
 {
-  header->layer          = 0;
+  header->layer          = MAD_LAYER_I;
   header->mode           = 0;
   header->mode_extension = 0;
   header->emphasis       = 0;


### PR DESCRIPTION
`enum mad_layer` has no variant with a discriminator equal to zero. Thus, using a default-initialized frame in rust causes various problems, including segfaults and inexplicable EOF errors (#31). The solution is to initialize `header->layer` to a valid `enum mad_layer` value.

This is something that should probably be fixed upstream, though I have no idea who, if anyone, is responsible for maintaining libmad, so I fixed it here since it only seems to affect Rust usage.